### PR TITLE
Fixed bug when deleting a toggled on switch

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -638,11 +638,16 @@ impl Circuit {
                 let &SwitchState {
                     input_cluster_index,
                     output_cluster_index,
+                    switched,
                     ..
                 } = state;
 
                 self.simulation
                     .remove_flop(input_cluster_index, output_cluster_index);
+
+                if switched {
+                    self.simulation.unpower(input_cluster_index);
+                }
 
                 self.simulation.free_cluster(input_cluster_index);
 


### PR DESCRIPTION
Deleting a toggled on button would not unpower the cluster that it was connected to (that bug was caught by an assertion).